### PR TITLE
Make minimum Emacs 26.1 instead of 27.1

### DIFF
--- a/oauth2-auto.el
+++ b/oauth2-auto.el
@@ -175,7 +175,6 @@ from the plstore. Cache data if a miss occurs."
 
 ;; Main entry point
 
-;;;###autoload
 (aio-defun oauth2-auto-plist (username provider)
   "Returns a 'oauth2-token structure for USERNAME and PROVIDER."
   ; Check the plstore for the requested username and provider
@@ -195,7 +194,6 @@ from the plstore. Cache data if a miss occurs."
 (defun oauth2-auto-plist-sync (username provider)
   (aio-wait-for (oauth2-auto-plist username provider)))
 
-;;;###autoload
 (aio-defun oauth2-auto-access-token (username provider)
   "Returns the access-token string used to authenticate user
 USERNAME to PROVIDER."

--- a/oauth2-auto.el
+++ b/oauth2-auto.el
@@ -190,9 +190,24 @@ from the plstore. Cache data if a miss occurs."
        (aio-await
         (oauth2-auto-refresh-or-authenticate username provider plist))))))
 
+(aio-defun oauth2-auto-force-reauth (username provider)
+  "Authenticates USERNAME with PROVIDER again and saves to the plstore."
+  (oauth2-auto--plstore-write
+   username provider
+   (aio-await
+    (oauth2-auto-authenticate username provider))))
+
+
+(defun oauth2-auto-poll-promise (promise)
+  "Synchronously wait for PROMISE, polling every SECONDS seconds."
+  (setq seconds 3)
+  (while (null (aio-result promise))
+    (sleep-for seconds))
+  (funcall (aio-result promise)))
+
 ;;;###autoload
 (defun oauth2-auto-plist-sync (username provider)
-  (aio-wait-for (oauth2-auto-plist username provider)))
+  (oauth2-auto-poll-promise (oauth2-auto-plist username provider)))
 
 (aio-defun oauth2-auto-access-token (username provider)
   "Returns the access-token string used to authenticate user
@@ -202,7 +217,7 @@ USERNAME to PROVIDER."
 
 ;;;###autoload
 (defun oauth2-auto-access-token-sync (username provider)
-  (aio-wait-for (oauth2-auto-access-token username provider)))
+  (oauth2-auto-poll-promise (oauth2-auto-access-token username provider)))
 
 
 ;; Making and encoding requests

--- a/oauth2-auto.el
+++ b/oauth2-auto.el
@@ -5,7 +5,7 @@
 ;; Author: Adrià Garriga-Alonso <adria.garriga@gmail.com>
 ;; Version: 0.1
 ;; Keywords: comm oauth2
-;; Package-Requires: ((emacs "27.1") (aio "1.0") (dash "2.19"))
+;; Package-Requires: ((emacs "26.1") (aio "1.0") (dash "2.19"))
 
 ;; This file is part of GNU Emacs.
 


### PR DESCRIPTION
`aio` has a minimum version of 26.1 at this time (see [aio.el](https://github.com/skeeto/emacs-aio/blob/da93523e235529fa97d6f251319d9e1d6fc24a41/aio.el)), `dash` is minimum Emacs 24, and `plstore` has been part of Emacs [since at least 2011](https://github.com/emacs-mirror/emacs/commits/21fe2ebec8b63d5fd0a570ed0c907802ab83f991/lisp/gnus/plstore.el?browsing_rename_history=true&new_path=lisp/plstore.el&original_branch=365e01cc9f64ce6ca947ccfd8612d60763280a37).

Context: https://github.com/kidd/org-gcal.el/pull/200 - I want to keep `org-gcal` compatible with Emacs 26.1, which was released only in 2020.